### PR TITLE
Calendar tooltips: fix the rendered html actually match the size of the ...

### DIFF
--- a/karl/views/static/calendar.css
+++ b/karl/views/static/calendar.css
@@ -929,9 +929,9 @@ select.category_paths {
 .tooltip {
   display: none;
   font-size: 110%;
-  height: 71px;
-  width: 150px;
-  padding: 5px;
+  height: 56px;
+  width: 140px;
+  padding: 5px 5px 20px;
   color: #333;
   z-index: 100;
   line-height: 1.2em;

--- a/karl/views/static/karl.js
+++ b/karl/views/static/karl.js
@@ -2332,6 +2332,24 @@ function scrollToTime() {
   $("#cal_hours_scroll").scrollTo(scrollPos, { duration: scrollDuration });
 }
 
+
+/* My tooltip: add a wrapper so we can handle 
+ * the overflow correctly */
+$.fn.myTooltip = function(options) {
+    return this.each(function() {
+        var el = $(this);
+        var tt = el.next();
+        var wrapper = $('<div></div>')
+            .height(tt.height())
+            .css('overflow', 'hidden');
+        tt.wrapInner(wrapper);
+        el.tooltip(options);
+    });
+};
+
+
+
+
 /** =CALENDAR INIT JAVASCRIPT
 ----------------------------------------------- */
 function initCalendar() {
@@ -2358,7 +2376,7 @@ function initCalendar() {
 
   // MONTH VIEW - hover to show (+) icon to add events
   $("#cal_month td").hover(mouseOverDay, mouseOutDay);
-  $("#cal_month .with_tooltip").tooltip({ tip: '.tooltip', offset: [8, 50], predelay: 250});
+  $("#cal_month .with_tooltip").myTooltip({ tip: '.tooltip', offset: [8, 50], predelay: 250});
 
   // WEEK/DAY VIEW - 
   var scrollHours = $("#cal_hours_scroll");
@@ -2369,8 +2387,8 @@ function initCalendar() {
   // Week tooltips
   var calScroll = $("#cal_scroll");
   if (calScroll.hasClass('cal_week')) {
-    $("#all_day .with_tooltip").tooltip({ tip: '.tooltip', offset: [8, -48], predelay: 250});
-    $("#cal_scroll .cal_hour_event .with_tooltip").tooltip({ tip: '.tooltip', offset: [12, 5], predelay: 250});
+    $("#all_day .with_tooltip").myTooltip({ tip: '.tooltip', offset: [8, -48], predelay: 250});
+    $("#cal_scroll .cal_hour_event .with_tooltip").myTooltip({ tip: '.tooltip', offset: [12, 5], predelay: 250});
   }
 
   var here_url = $("#karl-here-url").eq(0).attr('content');


### PR DESCRIPTION
...bubble.

Also make sure overlay works correctly, that is,
the bottom of the text cannot bleed under the tooltip
bubble's mouthpiece.
