### PR TITLE
When sorting folder listings by modified date, use fine-grained sorting.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ karl package Changelog
 Unreleased
 ----------
 
-
+- When sorting folder listings by modified date, use fine-grained sorting.
+  (lp:907527)
 
 3.81 (2012-02-03)
 -----------------

--- a/karl/views/batch.py
+++ b/karl/views/batch.py
@@ -17,6 +17,8 @@
 
 """Catalog results batching functions"""
 
+import datetime
+
 from pyramid.security import has_permission
 from pyramid.url import resource_url
 from pyramid.url import urlencode
@@ -258,12 +260,23 @@ def get_container_batch(container, request, batch_start=0, batch_size=20,
     if 'batch_size' in request.params:
         batch_size = int(request.params['batch_size'])
 
-    if sort_index:
+    if sort_index == 'modified_date':
+        now = datetime.datetime.now()
+
+        # Use fine-grained sort keys for the modified_date.
+        def sort_func(item, default):
+            try:
+                return item.modified
+            except AttributeError:
+                return now
+
+    elif sort_index:
         catalog = find_catalog(container)
         index = catalog[sort_index]
         # XXX this is not part of ICatalogIndex, but it happens to work
         # for most indexes. It might be useful to expand ICatalogIndex.
         sort_func = index.discriminator
+
     else:
         sort_func = None
 

--- a/karl/views/tests/test_batch.py
+++ b/karl/views/tests/test_batch.py
@@ -409,7 +409,7 @@ class TestGetContainerBatch(unittest.TestCase):
         self.assertEqual(batch['next_batch'], None)
         self.assertEqual(batch['batching_required'], False)
 
-    def test_sort(self):
+    def test_sort_by_creation_date(self):
         from datetime import datetime
         container = testing.DummyModel()
         container.catalog = {'creation_date': DummyCreationDateIndex()}
@@ -422,6 +422,23 @@ class TestGetContainerBatch(unittest.TestCase):
         self.assertEqual(len(batch['entries']), 3)
         self.assertEqual(
             [o.__name__ for o in batch['entries']], ['c', 'b', 'a'])
+
+    def test_sort_by_modified_date(self):
+        from datetime import datetime
+        container = testing.DummyModel()
+        container['a'] = testing.DummyModel(
+            modified=datetime(2007, 1, 1, 1, 1, 2))
+        container['b'] = testing.DummyModel(
+            modified=datetime(2007, 1, 1, 1, 1, 1))
+        container['c'] = testing.DummyModel(
+            modified=datetime(2007, 1, 1, 1, 1, 3))
+        container['d'] = testing.DummyModel()
+        request = testing.DummyRequest()
+        batch = self._callFUT(
+            container, request, sort_index='modified_date', reverse=True)
+        self.assertEqual(len(batch['entries']), 4)
+        self.assertEqual(
+            [o.__name__ for o in batch['entries']], ['d', 'c', 'a', 'b'])
 
 class TestGetFileLineBatch(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This is intended to fix https://bugs.launchpad.net/karl3/+bug/907527.
