### PR TITLE
Only users with admin privileges on a reference manual can move sections...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ karl package Changelog
 Unreleased
 ----------
 
+- Only users with admin privileges on a reference manual can move sections
+  up and down.
+
 - Return a 404 instead of General Error when someone visits /static/. (LP 
   #1038990)
 

--- a/karl/content/views/references.py
+++ b/karl/content/views/references.py
@@ -165,22 +165,24 @@ def reference_outline_view(context, request):
     # reorder something
     status_message = None
     subpath = request.params.get('subpath')
-    if subpath:
-        direction = request.params['direction']
-        status_message = move_subpath(context, subpath, direction)
 
     backto = {
         'href': resource_url(context.__parent__, request),
         'title': context.__parent__.title,
         }
 
+    user_can_edit = False
     actions = []
     if has_permission('create', context, request):
         addables = get_folder_addables(context, request)
         if addables is not None:
             actions.extend(addables())
     if has_permission('edit', context, request):
+        user_can_edit = True
         actions.append(('Edit', 'edit.html'))
+        if subpath:
+            direction = request.params['direction']
+            status_message = move_subpath(context, subpath, direction)
     if has_permission('delete', context, request):
         actions.append(('Delete', 'delete.html'))
     if has_permission('administer', context, request):
@@ -210,6 +212,7 @@ def reference_outline_view(context, request):
         'templates/show_referencemanual.pt',
         dict(api=api,
              actions=actions,
+             user_can_edit=user_can_edit,
              head_data=convert_to_script(client_json_data),
              tree=getTree(context, request, api),
              backto=backto,

--- a/karl/ux2/templates/show_referencemanual.pt
+++ b/karl/ux2/templates/show_referencemanual.pt
@@ -27,7 +27,7 @@
       <metal:macro define-macro="show_referencemanual_tree">
       <tal:items tal:repeat="item tree">
         <li>
-          <span class="sortingArrows">
+          <span class="sortingArrows" tal:condition="user_can_edit">
             <a href="${layout.here_url}?subpath=${item['subpath']}&amp;direction=up"
             ><img width="9" height="6" border="0" alt="Move up" 
                  src="${layout.static('images/arrowUp.gif')}" /></a>

--- a/karl/views/templates/snippets.pt
+++ b/karl/views/templates/snippets.pt
@@ -1061,7 +1061,7 @@ You are currently accessing KARL with Internet Explorer 6. This is an old browse
     <metal:macro define-macro="show_referencemanual_tree">
       <tal:items tal:repeat="item tree">
         <li>
-          <span class="sortingArrows">
+          <span class="sortingArrows" tal:condition="user_can_edit">
             <a href="${api.here_url}?subpath=${item['subpath']}&amp;direction=up"
             ><img width="9" height="6" border="0" alt="Move up" 
                  src="${api.static_url}/images/arrowUp.gif" /></a>


### PR DESCRIPTION
....now makes sure users without permission can't move the sections by going directly to a move url.
