### PR TITLE
Fixed bug where deletion of things like files and folders was broken due...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 karl package Changelog
 ======================
 
+Unreleased
+----------
+
+- Fixed bug where deletion of things like files and folders was broken due to 
+  Repozitory not being able to access user's identity after context was removed
+  from tree.  (LP #1045483)
+
 3.93 (2012-09-03)
 -----------------
 

--- a/karl/application.py
+++ b/karl/application.py
@@ -82,18 +82,18 @@ def configure_karl(config, load_zcml=True):
 
 
 def group_finder(identity, request):
+    # Might be repoze.who policy which uses an identity dict
     if isinstance(identity, dict):
-        userid = identity.get('repoze.who.userid')
-        if userid is None:
-            userid = identity.get('id')
-            if userid is None:
-                return None
-    else:
-        userid = identity
-    users = find_users(request.context)
-    user = users.get(userid)
+        return identity['groups']
+
+    # Might be cached
+    user = request.environ.get('karl.identity')
+    if user is None:
+        users = find_users(request.context)
+        user = users.get(identity)
     if user is None:
         return None
+    request.environ['karl.identity'] = user # cache for later
     return user['groups']
 
 


### PR DESCRIPTION
... to

Repozitory not being able to access user's identity after context was removed
from tree.  (LP #1045483)
