### PR TITLE
Fixed link to login form in the password reset completed page.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ karl package Changelog
 Unreleased
 ----------
 
+- Fixed link to login form in the password reset completed page.
+
 - Fixed bug in profile display introduced by new Chrome version.
   (LP #1078319)
 

--- a/karl/views/templates/reset_complete.pt
+++ b/karl/views/templates/reset_complete.pt
@@ -7,7 +7,7 @@
 
     <p>Click the button below to log in with your new password.</p>
 
-    <form method="post" action="${api.app_url}/login"
+    <form method="post" action="${api.app_url}/login.html"
          xml:id="contentform">
         <input type="hidden" name="login" value="${login}" />
         <input type="hidden" name="password" value="${password}" />


### PR DESCRIPTION
Works on karldev
