### PR TITLE
Do case-insensitive matching to weed out duplicates in the BCC handling.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 karl package Changelog
 ======================
 
+Unreleased
+----------
+
+- Do case-insensitive matching to weed out duplicates in the BCC handling.
+  (Gocept #90973)
+
 3.116 (2013-11-13)
 ------------------
 

--- a/karl/adapters/mailin.py
+++ b/karl/adapters/mailin.py
@@ -126,14 +126,14 @@ class MailinDispatcher(object):
 
         to = self.getAddrList(message, 'To')
 
-        seen = set([x[1] for x in to])
+        seen = set([x[1].lower() for x in to])
         to = to + [x for x in self.getAddrList(message, 'Cc')
-                      if x[1] not in seen]
+                      if x[1].lower() not in seen]
 
         # Include BCC'ed targets
-        seen = set([x[1] for x in to])
+        seen = set([x[1].lower() for x in to])
         to = to + [x for x in self.getAddrList(message, 'X-Original-To')
-                      if x[1] not in seen]
+                      if x[1].lower() not in seen]
 
         info = {
             'to': to,

--- a/karl/adapters/tests/test_mailin.py
+++ b/karl/adapters/tests/test_mailin.py
@@ -187,8 +187,8 @@ class MailinDispatcherTests(unittest.TestCase):
         cf['testing'] = self._makeContext()
         mailin = self._makeOne(context)
         message = DummyMessage()
-        message.to = ('Testing Tool <testing+tool-12345@example.com>',)
-        message.x_original_to = ('testing+tool-12345@example.com',)
+        message.to = ('Testing Tool <testing+tool-12345A@example.com>',)
+        message.x_original_to = ('testing+tool-12345a@example.com',)
 
         info = mailin.getMessageTargets(message)
 
@@ -199,7 +199,7 @@ class MailinDispatcherTests(unittest.TestCase):
         self.assertEqual(info['report'], None)
         self.assertEqual(info['community'], 'testing')
         self.assertEqual(info['tool'], 'tool')
-        self.assertEqual(info['in_reply_to'], '12345')
+        self.assertEqual(info['in_reply_to'], '12345A')
 
     def test_getMessageTargets_reply_invalid_community(self):
         context = self._makeRoot()


### PR DESCRIPTION
I'm happy to merge and release myself.  I'm not sure where governance is on this project, though, so figured I'd send up a flag here, first.  This was requested by Gocept for a continuing problem with duplicate posts via mailin for their customers.
