### PR TITLE
Fix loads/stores statistics in connection stats (Fixes LP #1378058)

### DIFF
--- a/karl/application.py
+++ b/karl/application.py
@@ -222,11 +222,14 @@ def root_factory(request, name='site'):
     # "finished" function has a chance to read their per-request values,
     # and they will appear to always be zero.
 
+    if connstats_file is not None:
+        request.add_finished_callback(finished)
+
     connection = get_connection(request)
+
     if connstats_file is not None:
         before = time.time()
         loads_before, stores_before = connection.getTransferCounts()
-        request.add_finished_callback(finished)
 
     folder = connection.root()
     if name not in folder:


### PR DESCRIPTION
The code that sets up the 'finished' callback has comments explaining why order is important, but then the code was doing things in the wrong order anyway.
