### PR TITLE
Begin the migration to Newt DB by adding a newt tag to the  configuration, causing the newt table to be updated.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 karl package Changelog
 ======================
 
+- Begin the migration to Newt DB by adding a ``newt tag`` to the
+  configuration, causing the ``newt`` table to be updated.
+
 4.31.1 (2017-04-17)
 ===================
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -405,7 +405,7 @@ relstorage_cache_prefix =
 cache_local_mb =
 cache_local_object_max =
 text =
-  %import relstorage
+  %import newt.db
   %define INSTANCE ${buildout:directory}
 
   <zodb>
@@ -413,9 +413,11 @@ text =
     ${:zodb_cache_size_bytes}
     pool-size ${:zodb_pool_size}
     <relstorage>
-      <postgresql>
-        dsn ${karldb:dsn}
-      </postgresql>
+      <newt>
+        <postgresql>
+          dsn ${karldb:dsn}
+        </postgresql>
+      </newt>
       shared-blob-dir False
       blob-dir $INSTANCE/var/blob_cache
       blob-cache-size 1gb

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -414,6 +414,7 @@ text =
     pool-size ${:zodb_pool_size}
     <relstorage>
       <newt>
+        transform karl.models.newttransform.transform
         <postgresql>
           dsn ${karldb:dsn}
         </postgresql>

--- a/karl/models/newttransform.py
+++ b/karl/models/newttransform.py
@@ -1,0 +1,15 @@
+import json
+import zlib
+
+def transform(class_name, state):
+    if class_name == 'karl.content.models.adapters._CachedData':
+        state = json.loads(state)
+        text = zlib.decompress(state['data']['hex'].decode('hex'))
+        try:
+            text = text.decode(
+                state.get('encoding', 'ascii')).replace('\x00', '')
+        except UnicodeDecodeError:
+            text = ''
+
+        return dict(text=text)
+

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ requires = [
     'user-agents',
     'pysaml2',
     'pyyaml',
+    'newt.db',
 ]
 
 tests_require = ['coverage', 'mock', 'nose', 'zope.testing']

--- a/versions.cfg
+++ b/versions.cfg
@@ -427,4 +427,4 @@ zc.recipe.deployment = 1.3.0
 
 # Required by:
 # karl==4.31.1
-newt.db = 0.5.3
+newt.db = 0.6.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -422,3 +422,9 @@ pyparsing = 2.2.0
 
 # Added by buildout at 2017-04-11 17:32:18.189429
 zc.recipe.deployment = 1.3.0
+
+# Added by buildout at 2017-04-18 20:11:21.042744
+
+# Required by:
+# karl==4.31.1
+newt.db = 0.5.3


### PR DESCRIPTION
This should get merged and tagged before the prod deployment on Sunday.

This has already been deployed to staging.