### PR TITLE
Fixed: incorrect var settings

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -144,7 +144,7 @@ framestats = true
 slowlog = slowlog = false
 timezone =
 connection_stats_threshhold =
-  connection_stats_filename = %(var)s/log/connection_stats.csv
+  connection_stats_filename = ${:var}/log/connection_stats.csv
   connection_stats_threshhold = 0.0
 pipeline_debug =
   debug = true
@@ -152,7 +152,7 @@ pipeline_debug =
   js_devel_mode = false
 
 mailout_throttle = 30
-mailout_stats_dir = %(var)s/mailout_stats_dir
+mailout_stats_dir = ${:var}/mailout_stats_dir
 offline_app_url = karl.example.org
 system_email_domain = example.org
 system_list_subdomain =
@@ -216,14 +216,14 @@ text =
   ${:admin}
   ${:mail_white_list}
   update.timestamp = http://karlhosting.github.com/TIMESTAMP.txt
-  error_monitor_dir = %(var)s/errors
+  error_monitor_dir = ${:var}/errors
   static_rev = ${:static_rev}
   postoffice.queue = ${:postoffice.queue}
   debugtoolbar = false
   zodbconn.uri = zconfig:${pg_zodb.conf:location}
   ${:zodbconn.uri.postoffice}
   tm.attempts = 5
-  mailin_trace_file = %(var)s/mailin_trace
+  mailin_trace_file = ${:var}/mailin_trace
 
   ${:redis}
 
@@ -308,7 +308,8 @@ text =
 
   [app:karl-search]
   use = karl
-  connection_stats_filename = %(var)s/log/search_connection_stats.csv
+  var = ${:var}
+  connection_stats_filename = ${:var}/log/search_connection_stats.csv
   ${:statsd_uri}?prefix=search
 
   ${:urchin_filter}
@@ -319,13 +320,13 @@ text =
 
   [filter:responselogger]
   use = egg:repoze.debug#responselogger
-  trace_log = %(var)s/log/trace.log
+  trace_log = ${:var}/log/trace.log
 
   ${:statsd}
 
   [filter:profile]
   use = egg:repoze.profile
-  log_filename = %(var)s/log/karl.profile
+  log_filename = ${:var}/log/karl.profile
   discard_first_request = true
   path = /__profile__
   #flush_at_shutdown = true


### PR DESCRIPTION
I misunderstood how the ``var`` variable was set and used.

Need actual setting in the karl-search app.

Elsewhere, use ${:var} (buildout substitution rather than %(var)s.