### PR TITLE
Fix office_dump to reflect change in path indexing.

### DIFF
--- a/karl/scripts/pgevolve.py
+++ b/karl/scripts/pgevolve.py
@@ -257,3 +257,5 @@ class KarlEvolver(Evolver):
                newtqbe.get_community_zoid_sql)
     evolve8 = NonTransactional(*newtqbe.qbe.index_sql('community'))
     evolve9 = analyze
+
+    evolve10 = ("get_path(state)", newtqbe.get_path_sql)

--- a/karl/views/admin.py
+++ b/karl/views/admin.py
@@ -585,15 +585,16 @@ def statistics_csv_view(request):
     return request.get_response(FileApp(path).get)
 
 def office_dump_csv(request):
+    from ZODB.utils import u64
     cursor = request.context._p_jar._storage.ex_cursor('office_dump')
     cursor.execute("""
     select get_path(state),
            state->>'modified', state->>'modified_by', state->>'title',
            state->>'mimetype'
     from newt
-    where get_path(state) like '/offices/%'
+    where get_community_zoid(zoid, class_name, state) = %s
       and class_name = 'karl.content.models.files.CommunityFile'
-    """)
+    """, (u64(find_site(request.context)['offices']._p_oid),))
     f = StringIO()
     writerow = csv.writer(f).writerow
     writerow(('File Title', 'Office',


### PR DESCRIPTION
We no-longer create a path index, but rather a community (zoid)
index. Changed office_dump to use that.  We still need a get_path
function to allow paths to be computed in SQL, so that was added back.