### PR TITLE
Digest workaround and better db closer

### DIFF
--- a/karl/scripts/digest.py
+++ b/karl/scripts/digest.py
@@ -41,3 +41,4 @@ def main(argv=sys.argv):
         only_one(digest, registry, 'digest')(
             root, closer, registry, args.frequency)
     closer()
+    import gc; gc.collect() # Work around relstorage cache bug.


### PR DESCRIPTION
Work-around possible relstorage cffi/local-cache bug, see https://github.com/zodb/relstorage/issues/184

Also fixed the atexit db close logic.
