### PR TITLE
Fix login error

### DIFF
--- a/karl/views/login.py
+++ b/karl/views/login.py
@@ -82,10 +82,11 @@ def login_view(context, request):
         left = context.login_tries.get(login, max_retries)
         left = left - 1
 
-        profile = None
+        users = find_users(context)
+        user = users.get_by_login(login)
         profiles = find_profiles(context)
-        if profiles is not None:
-            profile = profiles.get(login)
+        profile = profiles.get(user['id']) if user else None
+
         # max tries almost reached, send email warning
         if left == 2 and profile is not None:
             reset_url = request.resource_url(profile, 'change_password.html')
@@ -116,8 +117,6 @@ def login_view(context, request):
             # only send email the first time
             if profile is not None and left == 0:
                 context.login_tries[login] = -1
-                users = find_users(context)
-                user = users.get_by_id(login)
                 request_password_reset(user, profile, request)
             page_title = 'Access to %s is locked' % settings.get('system_name', 'KARL')
             api = TemplateAPI(context, request, page_title)


### PR DESCRIPTION
This commits fixes the following error seen in the wild a couple of times on

2017-05-11:

TypeError: 'NoneType' object has no attribute '__getitem__'
Exception when processing https://karl.soros.org/login.html
Referer: https://karl.soros.org/login.html?reason=Not+logged+in

Traceback (most recent call last):
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid-1.2.1-py2.7.egg/pyramid/tweens.py", line 17, in excview_tween
    response = handler(request)
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid_tm-0.5-py2.7.egg/pyramid_tm/__init__.py", line 107, in tm_tween
    return response
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid_tm-0.5-py2.7.egg/pyramid_tm/__init__.py", line 75, in __exit__
    return self._retry_or_raise(t, v, tb)
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid_tm-0.5-py2.7.egg/pyramid_tm/__init__.py", line 60, in _retry_or_raise
    reraise(t, v, tb) # otherwise reraise the exception
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid_tm-0.5-py2.7.egg/pyramid_tm/__init__.py", line 100, in tm_tween
    response = handler(request)
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid-1.2.1-py2.7.egg/pyramid/router.py", line 153, in handle_request
    response = view_callable(context, request)
  File "/srv/osfkarl/.buildout/eggs/cp27mu/pyramid-1.2.1-py2.7.egg/pyramid/config/views.py", line 319, in viewresult_to_response
    result = view(context, request)
  File "/srv/osfkarl/production/99/karl/views/login.py", line 121, in login_view
    request_password_reset(user, profile, request)
  File "/srv/osfkarl/production/99/karl/views/resetpassword.py", line 152, in request_password_reset
    dict(login=user['login'],
TypeError: 'NoneType' object has no attribute '__getitem__'

Some observations about `login_view` preceding this patch:

- In order for the above error to occur, we'd have to find a profile but not a
  user for the given login.

- The profile is being looked up by treating the `login` as the user's id,
  which is incorrect.  We need to look up the user by `login` in `users` to
  get the user's id, in order to look up the profile.

- The primary reason we'd have a profile without a user is a user was
  deactivated.  It's also possible a user was trying to login with their id
  instead of their login, if they are one of those users for whom they differ.
  There are also two profiles in the 'active' state which do not have logins,
  so it could have been one of those two.

This patch corrects the process of looking up the user's profile.  The `users`
object is now properly consulted for the user id which corresponds to the
given login.  If a user's login is not in the users object, we won't find a
profile, so we also close the loophole that allowed the above error to occur.