### PR TITLE
Manage community ids in an auxiliary table

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -398,6 +398,7 @@ text =
     <relstorage>
       <newt>
         transform karl.models.newttransform.transform
+        auxiliary-tables karlex
         <postgresql>
           dsn ${karldb:dsn}
         </postgresql>
@@ -411,7 +412,6 @@ text =
       ${:relstorage_cache_prefix}
       ${:cache_local_mb}
       ${:cache_local_object_max}
-      cache-local-dir ${:cache-local-dir}
     </relstorage>
   </zodb>
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -422,7 +422,7 @@ zc.recipe.deployment = 1.3.0
 
 # Required by:
 # karl==4.31.1
-newt.db = 0.8.0
+newt.db = 0.9.0
 
 # Added by buildout at 2017-04-25 11:03:09.112017
 
@@ -434,4 +434,4 @@ setuptools = 35.0.1
 
 # Required by:
 # karl==4.31.1
-newt.qbe = 0.1.0
+newt.qbe = 0.1.1


### PR DESCRIPTION
This leverages a new feature of Newt.  After the Newt table is updated, the auxiliary tables get updated.  Because this is in a separate phase, it should be free of ordering issues that still seem to be plaguing getting community zoid updated properly.

This PR also gets rid of the persistent cache which is ineffective and slows restarts, increasing downtime during upgrades.
