### PR TITLE
Cleanup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,10 @@ karl package Changelog
 
 - Fixed: pgevolve didn't work with new or very old databases.
 
+- Cleanup some database artifacts that were no-longer needed.
+
+- Added a trigger to remove karkex records when packing.
+
 4.38.2 (2017-07-22)
 ===================
 

--- a/karl/models/newtqbe.py
+++ b/karl/models/newtqbe.py
@@ -34,33 +34,6 @@ qbe['interfaces'] = text_array("interfaces(class_name)", convert=iface_names)
 
 #############################################################################
 # community
-get_community_zoid_sql = """
-create or replace function get_community_zoid(
-  zoid_ bigint, class_name text, state jsonb)
-  returns bigint
-as $$
-declare
-  parent_class_name text;
-  parent_state jsonb;
-  parent_id bigint;
-begin
-  if state is null then return null; end if;
-  if class_name = 'karl.models.community.Community' then
-     return zoid_;
-  end if;
-  parent_id := (state -> '__parent__' ->> '::=>')::bigint;
-  if parent_id is null then return null; end if;
-  select newt.class_name, newt.state from newt where zoid = parent_id
-  into parent_class_name, parent_state;
-
-  if parent_class_name is null then
-    return null;
-  end if;
-
-  return get_community_zoid(parent_id, parent_class_name, parent_state);
-end
-$$ language plpgsql immutable;
-"""
 from ZODB.utils import u64
 qbe['community'] = scalar("karlex.community_zoid",
                           convert = lambda c: u64(c._p_oid))

--- a/karl/scripts/pgevolve.py
+++ b/karl/scripts/pgevolve.py
@@ -349,10 +349,10 @@ class KarlEvolver(Evolver):
     evolve22 = (
         "Remove unnecessary triggers and indexes and add delete trigger",
         """
-        drop function notify_object_state_changed() cascade;
-        drop function populate_community_zoid_triggerf() cascade;
-        drop function get_community_zoid(bigint, text, jsonb);
-        drop index newt_community_idx;
+        drop function if exists notify_object_state_changed() cascade;
+        drop function if exists populate_community_zoid_triggerf() cascade;
+        drop function if exists get_community_zoid(bigint, text, jsonb);
+        drop index    if exists newt_community_idx;
 
         create or replace function karlex_delete_on_state_delete()
           returns trigger

--- a/karl/views/admin.py
+++ b/karl/views/admin.py
@@ -564,8 +564,8 @@ def office_dump_csv(request):
     select get_path(state),
            state->>'modified', state->>'modified_by', state->>'title',
            state->>'mimetype'
-    from newt
-    where get_community_zoid(zoid, class_name, state) = %s
+    from newt natural join karlex
+    where community_zoid = %s
       and class_name = 'karl.content.models.files.CommunityFile'
     """, (u64(find_site(request.context)['offices']._p_oid),))
     f = StringIO()


### PR DESCRIPTION
- remove trigger and index for storing community zoid in newt state, which was unreliable. Now we store community zoid in the auxiliary table, ``karlex``.

- Add a trigger for deleting karlex records when the corresponding newt records are packed away.