### PR TITLE
Make blob-cache location overridable

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -387,6 +387,7 @@ relstorage_cache_prefix =
 cache_local_mb = cache-local-mb 100
 cache_local_object_max =
 cache-local-dir = ${buildout:directory}/var/pickle-cache
+blob-cache-local-dir = ${buildout:directory}/var/blob-cache
 text =
   %import newt.db
   %define INSTANCE ${buildout:directory}
@@ -404,7 +405,7 @@ text =
         </postgresql>
       </newt>
       shared-blob-dir False
-      blob-dir $INSTANCE/var/blob_cache
+      blob-dir ${:blob-cache-local-dir}
       blob-cache-size 1gb
       keep-history False
       read-only False


### PR DESCRIPTION
So in prod we can place blob cache in home directory so it's shared across releases.

Together with change to osideploy, this fixes #176 .