### PR TITLE
Fix arc2box

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 karl package Changelog
 ======================
 
+- Added an arc2box option to just refresh box authentication. We'll
+  create a cron job to run this weekly to keep the auth token alive.
+
 4.38.5 (2017-08-03)
 ===================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ karl package Changelog
 - Added an arc2box option to just refresh box authentication. We'll
   create a cron job to run this weekly to keep the auth token alive.
 
+- When normalizing file and directory names for box, don't lower case
+  or convert dots to dashes.
+
 4.38.5 (2017-08-03)
 ===================
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -129,6 +129,7 @@ login_cookie_max_age = 36000
 mail_white_list =
 static_rev =
 redis = redislog = false
+sentry =
 statsd_uri =
   statsd_uri = statsd://localhost:8125
 statsd =
@@ -205,6 +206,7 @@ text =
   mailin_trace_file = ${:var}/mailin_trace
 
   ${:redis}
+  ${:sentry}
 
   ${:statsd_uri}
   framestats = ${:framestats}

--- a/karl/box/archive.py
+++ b/karl/box/archive.py
@@ -386,6 +386,8 @@ def worker():
     parser = OptionParser(usage, description=__doc__)
     parser.add_option('-C', '--config', dest='config', default=None,
         help="Specify a paster config file. Defaults to $CWD/etc/karl.ini")
+    parser.add_option('-r', '--refresh-authentication', action='store_true',
+                      help="Refresh box authentication")
 
     options, args = parser.parse_args()
     if args:
@@ -399,6 +401,10 @@ def worker():
     registry = get_current_registry()
     queue = RedisArchiveQueue.from_settings(registry.settings)
     closer()
+
+    if options.refresh_authentication:
+        BoxClient(find_box(root), registry.settings).refresh(commit=True)
+        return
 
     transaction.commit()
     transaction.manager.explicit = True

--- a/karl/box/archive.py
+++ b/karl/box/archive.py
@@ -270,8 +270,6 @@ def copy_community_to_box(community):
                 try:
                     folder.upload(name, item.open())
                 except:
-                    transaction.abort()
-                    transaction.begin()
                     community.archive_copied = copied
                     community.archive_last_copied = joined
                     transaction.commit()
@@ -285,7 +283,6 @@ def copy_community_to_box(community):
         log.info("Resuming copy of: %s", resource_path(community))
     folder = box.root().get_or_make('Karl Archive', *path)
     if folder and not copied:
-        transaction.abort()
         raise ValueError(
             'Cannot archive community, folder already exists: %s' % (
                 '/' + '/'.join(path)))

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -65,6 +65,24 @@ class BoxClient(object):
         box.access_token = response['access_token']
         box.refresh_token = response['refresh_token']
 
+    def refresh(self, commit=False):
+        box = self.archive
+        response = self.session.post(self.token_url, data={
+            'grant_type': 'refresh_token',
+            'refresh_token': box.refresh_token,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }).json()
+
+        if 'error' in response:
+            raise BoxError(
+                response['error'], response['error_description'])
+
+        box.access_token = response['access_token']
+        box.refresh_token = response['refresh_token']
+        if commit:
+            transaction.commit()
+
     def api_url(self, *path):
         return self.api_base_url + '/'.join(map(str, path))
 

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -209,8 +209,8 @@ class BoxFolder(object):
             folder_id = response.json()['context_info']['conflicts'][0]['id']
         else:
             folder_id = response.json()['id']
-            folder = BoxFolder(client, folder_id)
-            self.contents()[name] = folder
+        folder = BoxFolder(client, folder_id)
+        self.contents()[name] = folder
         return folder
 
     def upload(self, name, f):

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from slugify import slugify
+from .slugify import slugify
 import transaction
 
 from persistent import Persistent

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -114,14 +114,14 @@ class BoxClient(object):
             }).json()
 
             if 'error' in response:
-                with transaction.manager:
-                    box.logout()
+                box.logout()
+                transaction.commit()
                 raise BoxError(
                     response['error'], response['error_description'])
 
-            with transaction.manager:
-                box.access_token = response['access_token']
-                box.refresh_token = response['refresh_token']
+            box.access_token = response['access_token']
+            box.refresh_token = response['refresh_token']
+            transaction.commit()
 
             kw['headers']['Authorization'] = 'Bearer ' + box.access_token
             response = session_method(url, *args, **kw)

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -1,16 +1,9 @@
-import json
-import requests
-import time
+import boxsdk
+import persistent
+import pyramid.traversal
 import transaction
 
-from persistent import Persistent
-from requests_toolbelt import MultipartEncoder
-
-from pyramid.traversal import find_root
-
-from .slugify import slugify
-
-class BoxArchive(Persistent):
+class BoxArchive(persistent.Persistent):
     """
     Persistent object for storing client state.
     """
@@ -25,259 +18,69 @@ class BoxArchive(Persistent):
     def logout(self):
         self.access_token = self.refresh_token = self.state = None
 
+    def store(self, access_token, refresh_token):
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        transaction.commit()
 
 def find_box(context):
     """
     Find the box archive, create one if necessary.
     """
-    root = find_root(context)
+    root = pyramid.traversal.find_root(context)
     box = root.get('box')
     if not box:
         root['box'] = box = BoxArchive()
     return box
 
-
 class BoxClient(object):
-    api_base_url = 'https://api.box.com/2.0/'
     authorize_url = 'https://app.box.com/api/oauth2/authorize'
-    token_url = 'https://app.box.com/api/oauth2/token'
-    upload_url = 'https://upload.box.com/api/2.0/files/content'
-    session = None
 
     def __init__(self, archive, settings):
         self.archive = archive
-        self.client_id = settings.get('box.client_id')
-        self.client_secret = settings.get('box.client_secret')
-        self.start_session()
+        self.oauth = boxsdk.OAuth2(
+            client_id=settings.get('box.client_id'),
+            client_secret=settings.get('box.client_secret'),
+            access_token = archive.access_token,
+            refresh_token = archive.refresh_token,
+            store_tokens = archive.store
+            )
+        self.client = boxsdk.Client(self.oauth)
 
-    def start_session(self):
-        if self.session is not None:
-            self.session.close()
-            time.sleep(66)
-        self.session = requests.Session()
-        adapter = requests.adapters.HTTPAdapter(max_retries=5)
-        self.session.mount('https://', adapter)
+    def refresh(self):
+        self.archive.store(*self.oauth.refresh(self.archive.access_token))
 
     def authorize(self, code):
         """
         Turn an authorization code into an access token
         """
-        response = self.session.post(self.token_url, data={
-            'grant_type': 'authorization_code',
-            'code': code,
-            'client_id': self.client_id,
-            'client_secret': self.client_secret,
-        }).json()
+        self.archive.store(*self.oauth.authenticate(code))
 
-        box = self.archive
-        box.access_token = response['access_token']
-        box.refresh_token = response['refresh_token']
+    def _get_or_make(self, folder, path):
+        if path:
+            contents = self.contents(folder)
+            name = path[0]
+            path = path[1:]
+            if name in contents:
+                folder = contents[name]
+            else:
+                folder = folder.create_subfolder(name)
 
-    def refresh(self, commit=False):
-        box = self.archive
-        response = self.session.post(self.token_url, data={
-            'grant_type': 'refresh_token',
-            'refresh_token': box.refresh_token,
-            'client_id': self.client_id,
-            'client_secret': self.client_secret
-        }).json()
-
-        if 'error' in response:
-            raise BoxError(
-                response['error'], response['error_description'])
-
-        box.access_token = response['access_token']
-        box.refresh_token = response['refresh_token']
-        if commit:
-            transaction.commit()
-
-    def api_url(self, *path):
-        return self.api_base_url + '/'.join(map(str, path))
-
-    def api_call(self, method, url, *args, **kw):
-        session_method = self.session.post
-        if method == 'get':
-            session_method = self.session.get
-        box = self.archive
-        headers = {'Authorization': 'Bearer ' + box.access_token or ''}
-        if 'headers' in kw:
-            headers.update(kw['headers'])
-        kw['headers'] = headers
-        response = session_method(url, *args, **kw)
-        if response.status_code == requests.codes.unauthorized:
-            # Refresh access token
-            response = self.session.post(self.token_url, data={
-                'grant_type': 'refresh_token',
-                'refresh_token': box.refresh_token,
-                'client_id': self.client_id,
-                'client_secret': self.client_secret
-            }).json()
-
-            if 'error' in response:
-                box.logout()
-                transaction.commit()
-                raise BoxError(
-                    response['error'], response['error_description'])
-
-            box.access_token = response['access_token']
-            box.refresh_token = response['refresh_token']
-            transaction.commit()
-
-            kw['headers']['Authorization'] = 'Bearer ' + box.access_token
-            response = session_method(url, *args, **kw)
-
-        return response
-
-    def download_file(self, file_id):
-        response = self.api_call(
-            'get',
-            self.api_url('files', file_id, 'content'),
-            stream=True)
-        return response.headers['Content-Type'], response.raw
-
-    def get_file_info(self, file_id):
-        response = self.api_call(
-            'get',
-            self.api_url('files', file_id))
-        return response.json()
-
-    def root(self):
-        return BoxFolder(self, 0)
-
-    def check_token(self):
-        box = self.archive
-        if box.logged_in:
-            # See whether or not we can actually make a call
-            try:
-                self.root().contents()
-            except BoxError:
-                # Probably refresh token has expired
-                box.logout()
-        return box.logged_in
-
-
-class BoxFolder(object):
-    _contents = None
-    name = None
-
-    def __init__(self, client, id):
-        self.client = client
-        self.id = id
-
-    def _folder_listing(self):
-        client = self.client
-        response = client.api_call(
-            'get',
-            client.api_url('folders', self.id, 'items')
-        )
-        files = response.json()['entries']
-        return files
-
-    def contents(self):
-        if self._contents is None:
-            self._contents = contents = {}
-            for entry in self._folder_listing():
-                factory = BoxFolder if entry['type'] == 'folder' else BoxFile
-                item = factory(self.client, entry['id'])
-                item.name = entry['name']
-                contents[item.name] = item
-        return self._contents
-
-    def items(self):
-        return self.contents().items()
-
-    def __getitem__(self, key):
-        return self.contents()[key]
-
-    def __nonzero__(self):
-        return bool(self.contents())
-
-    def __contains__(self, key):
-        return key in self.contents()
+            return self._get_or_make(folder, path)
+        else:
+            return folder
 
     def get_or_make(self, *path):
-        if not path:
-            return self
+        return self._get_or_make(self.client.folder(folder_id='0'), path)
 
-        name, path = path[0], path[1:]
-        if name in self:
-            return self.contents()[name].get_or_make(*path)
-        return self.mkdir(name).get_or_make(*path)
-
-    def mkdir(self, name):
-        client = self.client
-        url = client.api_url('folders')
-        data = json.dumps({
-            'name': name,
-            'parent': {'id': self.id}})
-        response = client.api_call('post', url, data=data)
-        if response.status_code == 408:
-            # the session hung.  Start a new session and try again.
-            client.start_session()
-            response = client.api_call('post', url, data=data)
-
-        if response.status_code == 409:
-            # folder already exists, which means we are resuming failed op
-            folder_id = response.json()['context_info']['conflicts'][0]['id']
-        else:
-            folder_id = response.json()['id']
-        folder = BoxFolder(client, folder_id)
-        self.contents()[name] = folder
-        return folder
-
-    def upload(self, name, f):
-        # some attachment file names may have hidden new lines and tabs, ugh
-        name = slugify(name)
-        data = MultipartEncoder([
-            ('attributes', json.dumps(
-                {'name': name, 'parent': {'id': self.id}})),
-            ('file', (name, f)),
-        ])
-
-        client = self.client
-        response = client.api_call(
-            'post',
-            client.upload_url,
-            data=data,
-            headers={'Content-Type': data.content_type})
-
-        if response.status_code == 408:
-            print 'THE SESSION HUNG.  START A NEW SESSION AND TRY AGAIN.'
-            client.start_session()
-            response = client.api_call(
-                'post',
-                client.upload_url,
-                data=data,
-                headers={'Content-Type': data.content_type})
-
-        if response.status_code == 409:
-            # file already exists, which means we are resuming failed op
-            file_id = response.json()['context_info']['conflicts']['id']
-        else:
-            try:
-                file_id = response.json()['entries'][0]['id']
-            except ValueError:
-                # something went wrong, retry in case it was a network hiccup
-                response = client.api_call(
-                    'post',
-                    client.upload_url,
-                    data=data,
-                    headers={'Content-Type': data.content_type})
-                file_id = response.json()['entries'][0]['id']
-        self.contents()[name] = uploaded = BoxFile(client, file_id)
-        return uploaded
-
-
-class BoxFile(object):
-
-    def __init__(self, client, id):
-        self.client = client
-        self.id = id
-
-
-class BoxError(Exception):
-
-    def __init__(self, error, description):
-        super(BoxError, self).__init__(description)
-        self.error = error
-        self.description = description
+    def contents(self, folder):
+        data = {}
+        offset = 0
+        while 1:
+            items = folder.get_items(9999, offset)
+            if items:
+                for item in items:
+                    data[item.name] = item
+                offset += len(items)
+            else:
+                return data

--- a/karl/box/client.py
+++ b/karl/box/client.py
@@ -38,9 +38,11 @@ class BoxClient(object):
 
     def __init__(self, archive, settings):
         self.archive = archive
+        self.client_id = settings.get('box.client_id')
+        self.client_secret = settings.get('box.client_secret')
         self.oauth = boxsdk.OAuth2(
-            client_id=settings.get('box.client_id'),
-            client_secret=settings.get('box.client_secret'),
+            client_id=self.client_id,
+            client_secret=self.client_secret,
             access_token = archive.access_token,
             refresh_token = archive.refresh_token,
             store_tokens = archive.store

--- a/karl/box/slugify.py
+++ b/karl/box/slugify.py
@@ -13,13 +13,8 @@ __version__ = '0.0.1'
 
 
 def slugify(string):
-
-    """
-    Slugify a unicode string.
-    Example:
-        >>> slugify(u"Héllø Wörld")
-        u"hello-world"
-    """
+    if isinstance(string, str):
+        string = string.decode('latin-1')
 
     return re.sub(r'[-\s]+', '-',
             unicode(

--- a/karl/box/slugify.py
+++ b/karl/box/slugify.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Adapted from:
+# https://github.com/zacharyvoase/slugify/blob/master/src/slugify.py
+# to leave dots alone and not lower case.
+
+"""A generic slugifier utility (currently only for Latin-based scripts)."""
+
+import re
+import unicodedata
+
+__version__ = '0.0.1'
+
+
+def slugify(string):
+
+    """
+    Slugify a unicode string.
+    Example:
+        >>> slugify(u"Héllø Wörld")
+        u"hello-world"
+    """
+
+    return re.sub(r'[-\s]+', '-',
+            unicode(
+                re.sub(r'[^.\w\s-]', '',
+                    unicodedata.normalize('NFKD', string)
+                    .encode('ascii', 'ignore'))
+                .strip()))

--- a/karl/box/tests/test_slugify.py
+++ b/karl/box/tests/test_slugify.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+class SlugifyTests(unittest.TestCase):
+
+    def test_slugify(self):
+        from ..slugify import slugify
+        self.assertEqual(slugify(u" Héllo\tWörld.\n"), 'Hello-World.')

--- a/karl/box/tests/test_slugify.py
+++ b/karl/box/tests/test_slugify.py
@@ -7,3 +7,4 @@ class SlugifyTests(unittest.TestCase):
     def test_slugify(self):
         from ..slugify import slugify
         self.assertEqual(slugify(u" Héllo\tWörld.\n"), 'Hello-World.')
+        self.assertEqual(slugify(" index.html\n"), 'index.html')

--- a/karl/box/views.py
+++ b/karl/box/views.py
@@ -15,8 +15,8 @@ from ..views.api import TemplateAPI
 from .client import (
     BoxArchive,
     BoxClient,
-    BoxError,
 )
+from boxsdk.exception import BoxException
 
 
 @view_config(context=Site,
@@ -65,7 +65,7 @@ class BoxArchiveViews(object):
                          query={'id': item.id})}
                     for name, item in self.client.root().items()
                 ]
-            except BoxError:
+            except BoxException:
                 # Apparently refresh tokens can expire, so this whole thing
                 # may be a house of cards.  For our purposes, log user out and
                 # make them log in again.

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ requires = [
     'pyramid_tm',
     'pyramid_zcml',
     'formish<0.9',
+    'raven',
     'redis', # archive to box
     'repoze.browserid',
     'repoze.catalog>=0.8.3',  # 'total' attribute of numdocs

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ requires = [
     'pyramid_multiauth',
     'pyramid_zodbconn',
     'python-dateutil',
-    'python-slugify',
     'Pillow',
     'pyramid',
     'pyramid_formish',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ except IOError:
 requires = [
     'admin5',
     'appendonly',
+    'boxsdk',
     'Chameleon>=2.0',
     'feedparser',
     'icalendar',

--- a/versions.cfg
+++ b/versions.cfg
@@ -434,3 +434,13 @@ newt.db = 0.9.0
 # Required by:
 # karl==4.31.1
 newt.qbe = 0.1.1
+
+# Added by buildout at 2017-08-08 13:08:55.132034
+
+# Required by:
+# raven==6.1.0
+contextlib2 = 0.5.5
+
+# Required by:
+# karl==4.31.1
+raven = 6.1.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -40,7 +40,6 @@ repoze.pgtextindex = 1.4
 repoze.postoffice = 0.25
 repoze.profile = 2.0
 repozitory = 1.3
-requests-toolbelt = 0.3.1
 schemaish = 0.5.6
 slowlog = 0.9
 superlance = 0.9
@@ -444,3 +443,10 @@ contextlib2 = 0.5.5
 # Required by:
 # karl==4.31.1
 raven = 6.1.0
+
+# Added by buildout at 2017-08-08 18:03:44.962174
+requests-toolbelt = 0.8.0
+
+# Required by:
+# karl==4.31.1
+boxsdk = 1.5.4


### PR DESCRIPTION
This addresses a number of issues:

- Fixes the way file names are made compatible with Box's (20th century) name restrictions to preserve file extensions by preserving dots.

- Changes the box client to use the Box SDK.  This seems to address most, if not all, stability issues.

  - Leverages data from Box about existing files to avoid having to keep a list of copied files in ZODB, which was causing a lot of transactions.

- Adds a ``-r/--refresh`` option to refresh auth tokens.  I'll add a cron job to run this weekly.  Hopefully, this will help avoid sources of failure we've seen in the past.

- Adds an option to explicitly archive a community from the command line. (Helpful for testing/debugging.)

- Adds sentry support so we can find out about errors without polling.  When OSF gets an account, I'll wire this up in osideploy.

Note that there's a fair chance that this will break authentication, but it looks like I'll need to test this in prod.